### PR TITLE
Update dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,18 +11,19 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
     - pip
-    - python >=3.5
+    - python >=3.7
     - setuptools
 
   run:
-    - python >=3.5
-    - sphinx
+    - python >=3.7
+    - sphinx >=1.8
+    - jinja2 >=2.10,<3.1
 
 test:
   imports:


### PR DESCRIPTION
With the latest release, the upstream dependencies [have changed](https://github.com/numpy/numpydoc/pull/369/files).

Most importantly, there is now an upper bound for Jinja2. This is how I realized something had changed: the `emd` package, which relies on `numpydoc` wasn't working on my system with the newest Jinja2.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
